### PR TITLE
Bump emacs dependency to 24.3

### DIFF
--- a/dune-format.el
+++ b/dune-format.el
@@ -4,7 +4,7 @@
 
 ;; Author: Steve Purcell <steve@sanityinc.com>
 ;; Keywords: languages
-;; Package-Requires: ((reformatter "0.6") (emacs "24.1"))
+;; Package-Requires: ((reformatter "0.6") (emacs "24.3"))
 ;; Package-Version: 0.1-pre
 ;; Homepage: https://github.com/purcell/emacs-dune-format
 


### PR DESCRIPTION
Reformatter 0.6 requires 24.3 :
https://github.com/purcell/emacs-reformatter/blob/0.6/reformatter.el